### PR TITLE
docs: correct cargo example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ This repository contains a pure Rust implementation of the inferencing engine fr
 To use the crate, add the following to your `Cargo.toml`:
 ```toml
 [dependencies]
-deepphonemizer-rs = "1.0.0"
+deepphonemizer = "1.0.0"
 ```
 
 Then, you can use the crate as follows:


### PR DESCRIPTION
I was a bit confused as to why this didn't work. Seems a stray `-rs` snook in